### PR TITLE
Update TodoistTask partial to conform to v1 spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Copied from the typings:
     getTaskById(id: StrInt): Promise<TodoistTask>;
 
     /** Updates a task and returns an empty body with the HTTP status code 204. */
-    updateTaskById(id: StrInt, params: PostTaskParameters): Promise<Axios.AxiosResponse>;
+    updateTaskById(id: StrInt, params: UpdateTaskParameters): Promise<Axios.AxiosResponse>;
 
     /**
      * Closes a task and returns an empty body with a HTTP status code 204.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Copied from the typings:
     getTasksFiltered(params: GetTaskParameters): Promise<TodoistTask[]>;
 
     /** Creates a new task and returns its value in a JSON format. */
-    createNewTask(params: PostTaskParameters): Promise<TodoistTask>;
+    createNewTask(params: CreateTaskParameters): Promise<TodoistTask>;
 
     /** Returns a task by id. */
     getTaskById(id: StrInt): Promise<TodoistTask>;

--- a/src/Partials/TodoistTasks.ts
+++ b/src/Partials/TodoistTasks.ts
@@ -4,7 +4,7 @@ import Axios = require("axios");
 import {
   StrInt,
   TodoistTask,
-  PostTaskParameters,
+  UpdateTaskParameters,
   GetTaskParameters,
   CreateTaskParameters
 } from "../types";
@@ -79,7 +79,7 @@ export namespace TodoistTasks {
   export const updateTaskById = (
     axiosInstance: Axios.AxiosInstance,
     id: StrInt,
-    parameters: PostTaskParameters
+    parameters: UpdateTaskParameters
   ): Promise<Axios.AxiosResponse> => {
     const { due_string, due_date, due_datetime } = parameters;
     if (maxOneArgExists(due_string, due_date, due_datetime)) {

--- a/src/Partials/TodoistTasks.ts
+++ b/src/Partials/TodoistTasks.ts
@@ -7,6 +7,7 @@ import {
   PostTaskParameters,
   GetTaskParameters,
 } from "../types";
+import { CreateTaskParameters } from "..";
 
 export namespace TodoistTasks {
   export const getAllTasks = (
@@ -47,7 +48,7 @@ export namespace TodoistTasks {
 
   export const createNewTask = (
     axiosInstance: Axios.AxiosInstance,
-    parameters: PostTaskParameters
+    parameters: CreateTaskParameters
   ): Promise<TodoistTask> => {
     const { due_string, due_date, due_datetime } = parameters;
     if (maxOneArgExists(due_string, due_date, due_datetime)) {

--- a/src/Partials/TodoistTasks.ts
+++ b/src/Partials/TodoistTasks.ts
@@ -5,7 +5,7 @@ import {
   StrInt,
   TodoistTask,
   PostTaskParameters,
-  GetTaskParameters
+  GetTaskParameters,
 } from "../types";
 
 export namespace TodoistTasks {
@@ -15,8 +15,8 @@ export namespace TodoistTasks {
     return new Promise((resolve, reject) =>
       axiosInstance
         .get("tasks")
-        .then(data => resolve(data.data))
-        .catch(err => reject(err))
+        .then((data) => resolve(data.data))
+        .catch((err) => reject(err))
     );
   };
 
@@ -25,19 +25,23 @@ export namespace TodoistTasks {
     parameters?: GetTaskParameters
   ): Promise<TodoistTask[]> => {
     if (!parameters) {
-      throw new Error("getTasksFiltered should be called with at least one argument. You might want getAllTasks instead.")
+      throw new Error(
+        "getTasksFiltered should be called with at least one argument. You might want getAllTasks instead."
+      );
     }
     const { filter, ids, label_id, project_id, section_id } = parameters;
     if (!maxOneArgExists(filter, ids, label_id, project_id, section_id)) {
-      throw new TypeError('Filter takes precedence over ids: only include one or the other');
+      throw new TypeError(
+        "Filter takes precedence over ids: only include one or the other"
+      );
     } else if (!maxOneArgExists(ids, project_id, label_id, section_id)) {
-      throw new TypeError('only one of ids should be specified');
+      throw new TypeError("only one of ids should be specified");
     }
     return new Promise((resolve, reject) =>
       axiosInstance
         .get("tasks", { params: parameters })
-        .then(data => resolve(data.data))
-        .catch(err => reject(err))
+        .then((data) => resolve(data.data))
+        .catch((err) => reject(err))
     );
   };
 
@@ -50,10 +54,10 @@ export namespace TodoistTasks {
       return new Promise((resolve, reject) =>
         axiosInstance
           .post("tasks", parameters, {
-            headers: { "Content-Type": "application/json" }
+            headers: { "Content-Type": "application/json" },
           })
-          .then(data => resolve(data.data))
-          .catch(err => reject(err))
+          .then((data) => resolve(data.data))
+          .catch((err) => reject(err))
       );
     }
     throw new TypeError('only one of the "due_*" parameters can be used');
@@ -66,8 +70,8 @@ export namespace TodoistTasks {
     return new Promise((resolve, reject) =>
       axiosInstance
         .get(`tasks/${id}`)
-        .then(data => resolve(data.data))
-        .catch(err => reject(err))
+        .then((data) => resolve(data.data))
+        .catch((err) => reject(err))
     );
   };
 
@@ -81,10 +85,10 @@ export namespace TodoistTasks {
       return new Promise((resolve, reject) =>
         axiosInstance
           .post(`tasks/${id}`, parameters, {
-            headers: { "Content-Type": "application/json" }
+            headers: { "Content-Type": "application/json" },
           })
-          .then(res => resolve(res))
-          .catch(err => reject(err))
+          .then((res) => resolve(res))
+          .catch((err) => reject(err))
       );
     }
     throw new TypeError('only one of the "due_*" parameters can be used');
@@ -97,8 +101,8 @@ export namespace TodoistTasks {
     return new Promise((resolve, reject) =>
       axiosInstance
         .post(`tasks/${id}/close`)
-        .then(res => resolve(res))
-        .catch(err => reject(err))
+        .then((res) => resolve(res))
+        .catch((err) => reject(err))
     );
   };
 
@@ -109,8 +113,8 @@ export namespace TodoistTasks {
     return new Promise((resolve, reject) =>
       axiosInstance
         .post(`tasks/${id}/reopen`)
-        .then(res => resolve(res))
-        .catch(err => reject(err))
+        .then((res) => resolve(res))
+        .catch((err) => reject(err))
     );
   };
 
@@ -121,8 +125,8 @@ export namespace TodoistTasks {
     return new Promise((resolve, reject) =>
       axiosInstance
         .delete(`tasks/${id}`)
-        .then(res => resolve(res))
-        .catch(err => reject(err))
+        .then((res) => resolve(res))
+        .catch((err) => reject(err))
     );
   };
 }

--- a/src/Partials/TodoistTasks.ts
+++ b/src/Partials/TodoistTasks.ts
@@ -6,8 +6,8 @@ import {
   TodoistTask,
   PostTaskParameters,
   GetTaskParameters,
+  CreateTaskParameters
 } from "../types";
-import { CreateTaskParameters } from "..";
 
 export namespace TodoistTasks {
   export const getAllTasks = (

--- a/src/Partials/TodoistTasks.ts
+++ b/src/Partials/TodoistTasks.ts
@@ -22,8 +22,17 @@ export namespace TodoistTasks {
 
   export const getTasksFiltered = (
     axiosInstance: Axios.AxiosInstance,
-    parameters: GetTaskParameters
+    parameters?: GetTaskParameters
   ): Promise<TodoistTask[]> => {
+    if (!parameters) {
+      throw new Error("getTasksFiltered should be called with at least one argument. You might want getAllTasks instead.")
+    }
+    const { filter, ids, label_id, project_id, section_id } = parameters;
+    if (!maxOneArgExists(filter, ids, label_id, project_id, section_id)) {
+      throw new TypeError('Filter takes precedence over ids: only include one or the other');
+    } else if (!maxOneArgExists(ids, project_id, label_id, section_id)) {
+      throw new TypeError('only one of ids should be specified');
+    }
     return new Promise((resolve, reject) =>
       axiosInstance
         .get("tasks", { params: parameters })

--- a/src/TodoistApiREST.ts
+++ b/src/TodoistApiREST.ts
@@ -8,13 +8,14 @@ import { TodoistComments } from "./Partials/TodoistComments";
 import { TodoistLabels } from "./Partials/TodoistLabels";
 import {
   GetTaskParameters,
-  PostTaskParameters,
+  UpdateTaskParameters,
   StrInt,
   TodoistProject,
   TodoistTask,
   TodoistComment,
   Attachment,
-  TodoistLabel
+  TodoistLabel,
+  CreateTaskParameters
 } from "./types";
 
 export default class TodoistApiREST {
@@ -89,7 +90,7 @@ export default class TodoistApiREST {
   /** Updates a task and returns an empty body with the HTTP status code 204. */
   public updateTaskById(
     id: StrInt,
-    params: PostTaskParameters
+    params: UpdateTaskParameters
   ): Promise<Axios.AxiosResponse> {
     return TodoistTasks.updateTaskById(this.axiosInstance, id, params);
   }

--- a/src/TodoistApiREST.ts
+++ b/src/TodoistApiREST.ts
@@ -77,7 +77,7 @@ export default class TodoistApiREST {
   }
 
   /** Creates a new task and returns its value in a JSON format. */
-  public createNewTask(params: PostTaskParameters): Promise<TodoistTask> {
+  public createNewTask(params: CreateTaskParameters): Promise<TodoistTask> {
     return TodoistTasks.createNewTask(this.axiosInstance, params);
   }
 

--- a/src/__tests__/Tasks.spec.ts
+++ b/src/__tests__/Tasks.spec.ts
@@ -32,28 +32,46 @@ describe("Todoist Tasks", () => {
   });
 
   describe("getTasksFiltered", () => {
+    it("should error if called with no parameters", () => {
+      // @ts-ignore
+      expect(() => {
+        // @ts-ignore
+        TodoistTasks.getTasksFiltered(mockInstance);
+      }).toThrow("getTasksFiltered should be called with at least one argument. You might want getAllTasks instead.")
+    })
+
     it("should pass the right arguments", () => {
       const args = {
-        project_id: 1234,
-        label_id: 5678,
-        filter: "foo"
+        filter: "foo",
+        lang: "US"
       };
       // @ts-ignore
       TodoistTasks.getTasksFiltered(mockInstance, args);
       expect(mockGet).toHaveBeenCalledWith("tasks", {
         params: {
-          project_id: 1234,
-          label_id: 5678,
-          filter: "foo"
+          filter: "foo",
+          lang: "US"
         }
       });
     });
 
     it("should return the correct data", async () => {
       // @ts-ignore
-      const data = await TodoistTasks.getTasksFiltered(mockInstance);
+      const data = await TodoistTasks.getTasksFiltered(mockInstance, {filter: "test"});
       expect(data).toEqual("foo");
     });
+ 
+    it("should throw an error if both filter and any id is defined", () => {
+      const failParams = {
+        filter: "hello world",
+        ids: ["hey"]
+      };
+      expect(() => {
+        // @ts-ignore
+        TodoistTasks.getTasksFiltered(mockInstance, failParams);
+      }).toThrow()      
+
+    })
   });
 
   describe("createNewTask", () => {

--- a/src/__tests__/Tasks.spec.ts
+++ b/src/__tests__/Tasks.spec.ts
@@ -1,14 +1,14 @@
 import { TodoistTasks } from "../Partials/TodoistTasks";
 
 describe("Todoist Tasks", () => {
-  const mockGet = jest.fn(() => new Promise(res => res({ data: "foo" })));
-  const mockPost = jest.fn(() => new Promise(res => res({ data: "bar" })));
-  const mockDelete = jest.fn(() => new Promise(res => res({ data: "baz" })));
+  const mockGet = jest.fn(() => new Promise((res) => res({ data: "foo" })));
+  const mockPost = jest.fn(() => new Promise((res) => res({ data: "bar" })));
+  const mockDelete = jest.fn(() => new Promise((res) => res({ data: "baz" })));
 
   const mockInstance = {
     get: mockGet,
     post: mockPost,
-    delete: mockDelete
+    delete: mockDelete,
   };
 
   afterEach(() => {
@@ -37,53 +37,56 @@ describe("Todoist Tasks", () => {
       expect(() => {
         // @ts-ignore
         TodoistTasks.getTasksFiltered(mockInstance);
-      }).toThrow("getTasksFiltered should be called with at least one argument. You might want getAllTasks instead.")
-    })
+      }).toThrow(
+        "getTasksFiltered should be called with at least one argument. You might want getAllTasks instead."
+      );
+    });
 
     it("should pass the right arguments", () => {
       const args = {
         filter: "foo",
-        lang: "US"
+        lang: "US",
       };
       // @ts-ignore
       TodoistTasks.getTasksFiltered(mockInstance, args);
       expect(mockGet).toHaveBeenCalledWith("tasks", {
         params: {
           filter: "foo",
-          lang: "US"
-        }
+          lang: "US",
+        },
       });
     });
 
     it("should return the correct data", async () => {
       // @ts-ignore
-      const data = await TodoistTasks.getTasksFiltered(mockInstance, {filter: "test"});
+      const data = await TodoistTasks.getTasksFiltered(mockInstance, {
+        filter: "test",
+      });
       expect(data).toEqual("foo");
     });
- 
+
     it("should throw an error if both filter and any id is defined", () => {
       const failParams = {
         filter: "hello world",
-        ids: ["hey"]
+        ids: ["hey"],
       };
       expect(() => {
         // @ts-ignore
         TodoistTasks.getTasksFiltered(mockInstance, failParams);
-      }).toThrow()      
-
-    })
+      }).toThrow();
+    });
   });
 
   describe("createNewTask", () => {
     const passParameters = {
       content: "hello world",
-      due_string: "today"
+      due_string: "today",
     };
 
     const failParameters = {
       content: "hello world",
       due_string: "today",
-      due_date: "2018-01-01"
+      due_date: "2018-01-01",
     };
 
     it('should throw an error if more than one "due_" arguments are passed', () => {
@@ -130,13 +133,13 @@ describe("Todoist Tasks", () => {
   describe("updateTaskById", () => {
     const passParameters = {
       content: "hello world",
-      due_string: "today"
+      due_string: "today",
     };
 
     const failParameters = {
       content: "hello world",
       due_string: "today",
-      due_date: "2018-01-01"
+      due_date: "2018-01-01",
     };
 
     it('should throw an error if more than one "due_" arguments are passed', () => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -209,4 +209,34 @@ export type PostTaskParameters = {
   due_lang?: string;
 };
 
+export type CreateTaskParameters = {
+  /** Task content */
+  content: string;
+  description?: string
+  /** Task project id. If not set, task is put to user’s Inbox */
+  project_id?: number;
+  section_id?: number;
+  parent_id?: number;
+  /** Non-zero integer value used by clients to sort tasks inside project */
+  order?: number;
+  /** Ids of labels associated with the task */
+  label_ids?: number[];
+  /** Task priority from 1 (normal) to 4 (urgent) */
+  priority?: number;
+  /**
+   * human-defined task due date
+   * (ex.: “next Monday”, “Tomorrow”).
+   * Value is set using local (not UTC) time.
+   */
+  due_string?: string;
+  /** Specific date in YYYY-MM-DD format relative to user’s timezone */
+  due_date?: string;
+  /** specific date and time in RFC3339 format in UTC */
+  due_datetime?: string;
+  /** 2-letter code specifying language in case due_string is not written in English */
+  due_lang?: string;
+  assignee?: number
+};
+
+
 export type StrInt = string | number;

--- a/src/types.ts
+++ b/src/types.ts
@@ -187,14 +187,11 @@ export type GetTaskParameters = {
 export type PostTaskParameters = {
   /** Task content */
   content: string;
-  /** Task project id. If not set, task is put to user’s Inbox */
-  project_id?: number;
-  /** Non-zero integer value used by clients to sort tasks inside project */
-  order?: number;
+  description: string;
   /** Ids of labels associated with the task */
   label_ids?: number[];
   /** Task priority from 1 (normal) to 4 (urgent) */
-  priority?: number;
+  priority?: 1 | 2 | 3 | 4;
   /**
    * human-defined task due date
    * (ex.: “next Monday”, “Tomorrow”).
@@ -207,6 +204,7 @@ export type PostTaskParameters = {
   due_datetime?: string;
   /** 2-letter code specifying language in case due_string is not written in English */
   due_lang?: string;
+  assignee?: number;
 };
 
 export type CreateTaskParameters = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -169,6 +169,8 @@ export interface TodoistTask {
 export type GetTaskParameters = {
   /** Filter tasks by project id */
   project_id?: number;
+  /** Filter tasks by section id */
+  section_id?: number;
   /** Filter tasks by label */
   label_id?: number;
   /** Filter by any supported filter */
@@ -178,6 +180,7 @@ export type GetTaskParameters = {
    * if it differs from default English
    */
   lang?: string;
+  ids?: number[];
 };
 
 /** Please note that only one of the due_* fields can be used at the same time (due_lang is a special case). */

--- a/src/types.ts
+++ b/src/types.ts
@@ -184,7 +184,7 @@ export type GetTaskParameters = {
 };
 
 /** Please note that only one of the due_* fields can be used at the same time (due_lang is a special case). */
-export type PostTaskParameters = {
+export type UpdateTaskParameters = {
   /** Task content */
   content: string;
   description: string;


### PR DESCRIPTION
- fix: update GetTaskParameters to match v1 spec
- fix: update getTasksFiltered to properly handle multiple parameters
- test: update getTasksFiltered to test for the correct parameters
- style: run prettier
- fix: add new type CreateTaskParameters so CreateNewTask matches v1 spec
- refactor: add CreateTaskParameters to type import
- fix: ensure TodoistApiREST uses CreateTaskParameters when creating tasks
- fix: update PostTaskParameters to be compliant with v1 spec
- refactor: rename PostTaskParameters to UpdateTaskParameters everywhere
